### PR TITLE
Fix booking pagination parameters in controller

### DIFF
--- a/src/web/booking/controllers/booking.controller.ts
+++ b/src/web/booking/controllers/booking.controller.ts
@@ -55,6 +55,10 @@ export class BookingController {
     @Query('page', new ParseIntPipe({ optional: true })) page: number = 1,
     @Query('limit', new ParseIntPipe({ optional: true })) limit: number = 10
   ): Promise<ApiResponses<BookingResponseDto[]>> {
-    return this.bookingService.getCustomerBookings(currentUser,);
+    return this.bookingService.getCustomerBookings(currentUser, {
+      status,
+      page,
+      limit
+    });
   }
 }


### PR DESCRIPTION
### Description:
This PR fixes an issue in the booking controller where the` getBookings` endpoint was not passing the` status`, `page`, and `limit `query parameters to the service method. As a result, pagination and filtering did not work as expected.
Now, the controller correctly forwards these parameters, ensuring accurate data and pagination metadata in responses.

**Changes:**

- Pass` status`, `page,` and` limit `from query to` getCustomerBookings `service method.

**Impact:**

- Pagination and filtering for bookings now work as requested by the client.