### PR TITLE
Driver Activate/DeActivate API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ lerna-debug.log*
 .env.production.local
 .env.local
 
+# Database seeding scripts (for testing only)
+seed.ts
+seed.js
+
 # temp directory
 .temp
 .tmp

--- a/src/config/ormconfig.ts
+++ b/src/config/ormconfig.ts
@@ -18,7 +18,7 @@ dotenv.config();
 export const ormconfig: TypeOrmModuleOptions = {
   type: 'postgres',
   url: process.env.DB_URL,
-  ssl: { rejectUnauthorized: false },
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
   synchronize: true,
   entities: [
     Users,

--- a/src/dtos/update-driver-status.dto.ts
+++ b/src/dtos/update-driver-status.dto.ts
@@ -1,0 +1,70 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { UserStatus } from 'src/enums/user.enum';
+
+export class UpdateDriverStatusDto {
+  @ApiProperty({
+    description: 'New status for the driver',
+    enum: UserStatus,
+    example: UserStatus.ACTIVE,
+  })
+  @IsNotEmpty({ message: 'Status is required' })
+  @IsEnum(UserStatus, { message: 'Status must be a valid UserStatus value' })
+  status!: UserStatus;
+
+  @ApiProperty({
+    description: 'Reason for status change (optional, recommended for SUSPENDED)',
+    example: 'Multiple customer complaints',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}
+
+export class DriverStatusResponseDto {
+  @ApiProperty({
+    description: 'Driver ID',
+    example: 1,
+  })
+  driverId!: number;
+
+  @ApiProperty({
+    description: 'User ID',
+    example: 123,
+  })
+  userId!: number;
+
+  @ApiProperty({
+    description: 'Driver name',
+    example: 'John Doe',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: 'New status of the driver',
+    enum: UserStatus,
+    example: UserStatus.ACTIVE,
+  })
+  status!: UserStatus;
+
+  @ApiProperty({
+    description: 'Previous status of the driver',
+    enum: UserStatus,
+    example: UserStatus.INACTIVE,
+  })
+  previousStatus!: UserStatus;
+
+  @ApiProperty({
+    description: 'Reason for status change',
+    example: 'Account verification completed',
+    required: false,
+  })
+  reason?: string;
+
+  @ApiProperty({
+    description: 'Timestamp of status change',
+    example: '2025-12-12T10:30:00.000Z',
+  })
+  updatedAt!: Date;
+}

--- a/src/web/drivers/controllers/driver.controllers.ts
+++ b/src/web/drivers/controllers/driver.controllers.ts
@@ -5,6 +5,9 @@ import {
   ParseIntPipe,
   Query,
   UseGuards,
+  Patch,
+  Param,
+  Body,
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Authenticated } from 'src/commons/decorator/auth.decorator';
@@ -17,6 +20,7 @@ import { BookingResponseDto } from 'src/dtos/booking.dto';
 import { ReviewResponseDto, ReviewStatsDto } from 'src/dtos/review.dto';
 import { DriverDetailsResponseDto } from 'src/dtos/driver.details.dto';
 import { DriverQueryDto } from 'src/dtos/driver.query.dto';
+import { UpdateDriverStatusDto, DriverStatusResponseDto } from 'src/dtos/update-driver-status.dto';
 import { ApiResponses } from 'src/dtos/response';
 import { UserType } from 'src/enums/user.enum';
 import { JwtPayload as UserDetails } from 'src/web/auth/interface/jwt-payload.interface';
@@ -194,5 +198,32 @@ export class DriverController {
     @CurrentUser() currentUser: UserDetails,
   ): Promise<ApiResponses<ReviewStatsDto>> {
     return this.driverService.getDriverRatingStats(currentUser);
+  }
+
+  @Patch(':driverId/status')
+  @Roles(UserType.ADMIN)
+  @ApiOperation({
+    summary: 'Update driver status - Activate, Deactivate, or Suspend (Admin only)',
+    description:
+      'Allows administrators to change a driver\'s status. Use ACTIVE to activate, INACTIVE to deactivate, or SUSPENDED to suspend a driver account.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Driver status updated successfully',
+    type: DriverStatusResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Driver not found',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid status value',
+  })
+  async updateDriverStatus(
+    @Param('driverId', ParseIntPipe) driverId: number,
+    @Body() updateStatusDto: UpdateDriverStatusDto,
+  ): Promise<ApiResponses<DriverStatusResponseDto>> {
+    return this.driverService.updateDriverStatus(driverId, updateStatusDto);
   }
 }

--- a/src/web/drivers/interfaces/driver.service.ts
+++ b/src/web/drivers/interfaces/driver.service.ts
@@ -3,6 +3,7 @@ import { BookingResponseDto } from 'src/dtos/booking.dto';
 import { ReviewResponseDto, ReviewStatsDto } from 'src/dtos/review.dto';
 import { DriverDetailsResponseDto } from 'src/dtos/driver.details.dto';
 import { DriverQueryDto } from 'src/dtos/driver.query.dto';
+import { UpdateDriverStatusDto, DriverStatusResponseDto } from 'src/dtos/update-driver-status.dto';
 import { JwtPayload as UserDetails } from 'src/web/auth/interface/jwt-payload.interface';
 
 export const DRIVER_SERVICE = Symbol('DRIVER_SERVICE');
@@ -28,4 +29,9 @@ export interface DriverService {
   getDriverRatingStats(
     user: UserDetails,
   ): Promise<ApiResponses<ReviewStatsDto>>;
+
+  updateDriverStatus(
+    driverId: number,
+    updateStatusDto: UpdateDriverStatusDto,
+  ): Promise<ApiResponses<DriverStatusResponseDto>>;
 }

--- a/src/web/drivers/services/driver.servicesImpl.ts
+++ b/src/web/drivers/services/driver.servicesImpl.ts
@@ -16,6 +16,7 @@ import {
   DriverContactDto,
 } from 'src/dtos/driver.details.dto';
 import { DriverQueryDto } from 'src/dtos/driver.query.dto';
+import { UpdateDriverStatusDto, DriverStatusResponseDto } from 'src/dtos/update-driver-status.dto';
 import { apiResponse } from 'src/commons/utils/mapper';
 import { JwtPayload as UserDetails } from 'src/web/auth/interface/jwt-payload.interface';
 import { CarLending } from 'src/domain/entities/car.lending.model';
@@ -427,5 +428,55 @@ export class DriverServiceImpl implements DriverService {
           }
         : undefined,
     };
+  }
+
+  async updateDriverStatus(
+    driverId: number,
+    updateStatusDto: UpdateDriverStatusDto,
+  ): Promise<ApiResponses<DriverStatusResponseDto>> {
+    this.logger.log(
+      `Updating driver ${driverId} status to ${updateStatusDto.status}`,
+    );
+
+    // Find the driver by ID
+    const driver = await this.driverRepository.findOne({
+      where: { id: driverId },
+      relations: ['user'],
+    });
+
+    if (!driver) {
+      throw new NotFoundException(`Driver with ID ${driverId} not found`);
+    }
+
+    if (!driver.user) {
+      throw new NotFoundException(`User account not found for driver ${driverId}`);
+    }
+
+    // Store previous status
+    const previousStatus = driver.user.status!;
+
+    // Update user status
+    driver.user.status = updateStatusDto.status;
+    await this.userRepository.saveUser(driver.user);
+
+    this.logger.log(
+      `Driver ${driverId} status updated from ${previousStatus} to ${updateStatusDto.status}`,
+    );
+
+    // Build response
+    const response: DriverStatusResponseDto = {
+      driverId: driver.id!,
+      userId: driver.user.id!,
+      name: `${driver.user.firstName || ''} ${driver.user.lastName || ''}`.trim(),
+      status: updateStatusDto.status,
+      previousStatus: previousStatus,
+      reason: updateStatusDto.reason,
+      updatedAt: new Date(),
+    };
+
+    return apiResponse(
+      `Driver status successfully updated to ${updateStatusDto.status}`,
+      response,
+    );
   }
 }


### PR DESCRIPTION
**Summary**
Implemented API endpoint for administrators to activate, deactivate, or suspend driver accounts.

**Changes**

- ✅ Added PATCH /api/v1/drivers/:driverId/status endpoint
- ✅ Created DTOs for status update requests and responses
- ✅ Implemented service layer for driver status management
- ✅ Added admin-only access control
- ✅ Fixed database SSL configuration for local development

**API Details**
`Endpoint: PATCH /api/v1/drivers/:driverId/status`
Access: Admin only
Request Body:

```

{
  "status": "ACTIVE" | "INACTIVE" | "SUSPENDED",
  "reason": "Optional reason for the change"
}
```
Response

```
{
  "message": "Driver status successfully updated to ACTIVE",
  "data": {
    "driverId": 1,
    "userId": 123,
    "name": "John Doe",
    "status": "ACTIVE",
    "previousStatus": "INACTIVE",
    "reason": "KYC verification completed",
    "updatedAt": "2025-12-12T10:30:00.000Z"
  }
}
```


**Files Changed**

- `update-driver-status.dto.ts `- New DTOs
- `driver.service.ts -` Service interface
- `driver.servicesImpl.ts` - Service implementation
- `driver.controllers.ts `- Controller endpoint
- `ormconfig.ts `- Database SSL fix

**Testing**

Tested with seeded data for ACTIVE, INACTIVE, and SUSPENDED driver status changes. All validations and error handling working as expected.

